### PR TITLE
Enable `master` version to run plugin.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,7 +350,7 @@ const VERSION_REQUIREMENTS = ">= 0.7.2";
  */
 export const activate = async (context: ExtensionContext): Promise<any> => {
     const version = await getValeVersion();
-    if (semver.satisfies(version, VERSION_REQUIREMENTS)) {
+    if (semver.satisfies(version, VERSION_REQUIREMENTS) || version === 'master') {
         console.log("Found vale version", version,
             "satisfying", VERSION_REQUIREMENTS);
     } else {


### PR DESCRIPTION
fixes #2 

Since `0.7.2` was release two years ago, I guess we can get away with this.