### PR TITLE
feat: allow to configure path to vale binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Vale always runs from the workspace directory in either case, so if you put a [V
 Currently this extension only supports **Markdown, reStructuredText, LaTeX and plain text (.txt) documents**; please [open an issue][issue] or a pull request if you need support for **more document formats**, provided that [Vale][] supports them.
 
 [config]: https://errata-ai.github.io/vale/config/
+
+## Configuration
+
+- `vscode-vale.path`: Specifies the path to the `vale` executable, useful if you don't want to use the global binary. The path should be relative to the workspace root folder.

--- a/package.json
+++ b/package.json
@@ -78,5 +78,20 @@
     },
     "dependencies": {
         "semver": "^5.3.0"
+    },
+    "configuration": {
+        "type": "object",
+        "title": "VSCode vale",
+        "properties": {
+            "vscode-vale.path": {
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "default": null,
+                "description": "Specifies the path to the vale executable, useful if you don't want to use the global binary.",
+                "scope": "machine"
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #7 

I gave it a shot at providing a configuration for the binary location.

How can I test this locally?

-----
[View rendered README.md](https://github.com/emmenko/vscode-vale/blob/nm-config-binary-path/README.md)