### PR TITLE
feat: support mdx file extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,7 +272,7 @@ const runValeOnWorkspace = async (): Promise<ValeDiagnostics> => {
     // Explicitly find all elligible files ourselves so that we respect
     // "files.exclude", ie, only look at files that are included in the
     // workspace.
-    const extensions: ReadonlyArray<string> = ["md", "markdown", "txt", "rst", "tex", "adoc", "asciidoc"];
+    const extensions: ReadonlyArray<string> = ["md", "mdx", "markdown", "txt", "rst", "tex", "adoc", "asciidoc"];
     const pattern = `**/*.{${extensions.join(",")}}`;
     const uris = await workspace.findFiles(pattern);
     const results: ValeDiagnostics = new Map();


### PR DESCRIPTION
Alternatively, we can provide a new configuration option `vscode-vale.fileExtensions`, which users can use to override the default list.

WDYT?