### PR TITLE
fix: optional config for binary path

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "arrowParens": "always",
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 4,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -37,3 +37,18 @@ This extension supports:
 [Open an issue][issue] or a pull request if you need support for **more document formats**, provided that [Vale][] supports them.
 
 [config]: https://errata-ai.github.io/vale/config/
+
+## Configuration
+
+- `vscode-vale.path`: (default `vale`). Absolute path to the `vale` binary, useful if you don't want to use the global binary.
+
+  **Example**
+  ```js
+  {
+    // You can use ${workspaceFolder} it will be replaced by workspace folder path
+    "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/vale"
+
+    // or use some absolute path
+    "vscode-vale.path": "/some/path/to/vale"
+  }
+  ```

--- a/package.json
+++ b/package.json
@@ -50,6 +50,18 @@
                 "dark": "vale.png",
                 "light": "vale.png"
             }
+        },
+        "configuration": {
+            "type": "object",
+            "title": "VSCode vale",
+            "properties": {
+                "vscode-vale.path": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "vale",
+                    "description": "Absolute path to vale binary. Special var ${workspaceFolder} can be used in path (NOTE: in windows you can use '/' and can omit '.cmd' in path)"
+                }
+            }
         }
     },
     "activationEvents": [
@@ -68,6 +80,7 @@
     "devDependencies": {
         "@types/node": "^9.0",
         "@types/semver": "^5.3",
+        "@types/which": "^1.3",
         "tslint": "^5.8.0",
         "tslint-immutable": "^4.4.0",
         "tslint-language-service": "^0.9.6",
@@ -77,6 +90,7 @@
         "vscode": "^1.1.5"
     },
     "dependencies": {
-        "semver": "^5.3.0"
+        "semver": "^5.3.0",
+        "which": "^2.0.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,11 @@
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
 
+"@types/which@^1.3":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.2.tgz#9c246fc0c93ded311c8512df2891fb41f6227fdf"
+  integrity sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==
+
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -856,6 +861,11 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1732,6 +1742,13 @@ vso-node-api@6.1.2-preview:
     tunnel "0.0.4"
     typed-rest-client "^0.9.0"
     underscore "^1.8.3"
+
+which@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
+  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
+  dependencies:
+    isexe "^2.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Alright this should now fix the issue with the relative workspace path and the default global `vale` installation, as reported here: https://github.com/testthedocs/vscode-vale/pull/8#issuecomment-554643842

I took a deeper look at the [VSCode extension for Flow](https://github.com/flowtype/flow-for-vscode/) which has a similar option `pathToFlow` and based the implementation/fix off of that.

PS: I took the liberty of adding a `.prettierrc` file as I was getting a bunch of tslint errors/warnings in the editor. I can also open a separate PR if you prefer.

-----
[View rendered README.md](https://github.com/emmenko/vscode-vale/blob/nm-fix-config-path/README.md)